### PR TITLE
chore: address Trivy production dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "CosmosDB-with-Gremlin-API",
-    "version": "0.2.20",
+    "version": "0.2.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "CosmosDB-with-Gremlin-API",
-            "version": "0.2.20",
+            "version": "0.2.21",
             "hasInstallScript": true,
             "dependencies": {
                 "@azure/cosmos": "4.9.3",
                 "async": "2.6.4",
-                "axios": "1.16.0",
+                "axios": "1.18.0",
                 "gremlin": "3.7.3",
                 "lodash": "4.18.1",
                 "qs": "6.15.2"
@@ -1494,14 +1494,40 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/balanced-match": {
@@ -1548,16 +1574,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dependencies": {
         "@azure/cosmos": "4.9.3",
         "async": "2.6.4",
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "gremlin": "3.7.3",
         "lodash": "4.18.1",
         "qs": "6.15.2"
@@ -80,6 +80,7 @@
     },
     "overrides": {
         "minimatch": "10.2.4",
-        "uuid": "14.0.0"
+        "uuid": "14.0.0",
+        "brace-expansion": "5.0.8"
     }
 }


### PR DESCRIPTION
## Summary
- Address Trivy dependency vulnerabilities for `CosmosDB-with-Gremlin-API`: axios 1.16.0 → 1.18.0 (+ brace-expansion override).
- This plugin was listed in the Plugins develop Trivy production report (build 284434).
- Reference: https://teamcity.hackolade.com/buildConfiguration/Plugins_Build/284434

## Test plan
- [ ] CI passes
- [ ] Plugins develop Trivy re-scan no longer reports the fixed packages for production-impacted plugins
